### PR TITLE
PRIV-235688 - bump netty 4.1.129 -> 4.2.13 (CVE-2026-33870/42583/4258…

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -79,12 +79,12 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>4.1.129.Final</version>
+            <version>4.2.13.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.1.129.Final</version>
+            <version>4.2.13.Final</version>
         </dependency>
         <dependency>
             <groupId>${parent.groupId}</groupId>


### PR DESCRIPTION
Update Netty versions