### PR TITLE
PRIV-235688/PRIV-242564 - bump netty to 4.2.15.Final (netty-handler + codec CVEs)

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -79,17 +79,17 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>4.2.13.Final</version>
+            <version>4.2.15.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.2.13.Final</version>
+            <version>4.2.15.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>4.2.13.Final</version>
+            <version>4.2.15.Final</version>
         </dependency>
         <dependency>
             <groupId>${parent.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,16 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- PRIV-242564: force ALL netty artifacts (incl. netty-handler pulled transitively by
+                 awssdk:glue) to 4.2.15.Final - clears netty-handler CVE-2026-44249/45416 that the
+                 per-artifact netty-codec pins in common/pom.xml did not cover. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.2.15.Final</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>glue</artifactId>


### PR DESCRIPTION
## Summary
Bumps the shaded netty stack to **4.2.15.Final** so the kafkaconnect-converter uber-jars
(consumed by `content-classification`) no longer ship vulnerable netty.

- Adds `io.netty:netty-bom:4.2.15.Final` import to root `dependencyManagement` so **all** netty
  artifacts — including `netty-handler` pulled transitively by `awssdk:glue` — resolve to 4.2.15.
  The prior per-artifact `netty-codec*` pins did not cover `netty-handler` (stayed 4.1.124).
- Bumps the explicit `netty-codec`/`netty-codec-http`/`netty-codec-http2` pins in `common` 4.2.13 → 4.2.15.

## CVEs cleared
- netty-handler **CVE-2026-44249 / CVE-2026-45416** (HIGH) — PRIV-242564
- earlier netty-codec CVEs from PRIV-235688 (now at 4.2.15)

## Verification
Built `jsonschema-kafkaconnect-converter`; the shaded jar now bundles `netty-handler 4.2.15.Final`
(was 4.1.124) and all netty artifacts at 4.2.15.

After merge, tag **v1.1.25-7p** so jitpack publishes it for `securiti.aws.registry.version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)